### PR TITLE
fix: remove feature branch from release-please automation

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,7 +2,6 @@ on:
   push:
     branches:
       - main
-      - feature/release-please
 
 permissions:
   contents: write


### PR DESCRIPTION
# Description
The release-please action was enabled on pushes to a feature branch that was used for testing, but it is now reverted. 

# Fixes
* Remove `feature/release-please` from branch matching pattern to trigger release-please action.