### PR TITLE
fix: remove feature branch from release-please automation and name changes in publisher

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to PyPI
+name: Publish Library to PyPI
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
       - "*"
 
 jobs:
-  Publish:
+  publish:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,7 +2,6 @@ on:
   push:
     branches:
       - main
-      - feature/release-please
 
 permissions:
   contents: write


### PR DESCRIPTION
# Description
The release-please action was enabled on pushes to a feature branch that was used for testing, but it is now reverted. 

# Fixes
* Remove `feature/release-please` from branch matching pattern to trigger release-please action.