### PR TITLE
fix: Set publish automation to be dispatch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,6 @@
 name: Publish Library to PyPI
 
-on:
-  push:
-    tags:
-      - "*"
+on: workflow_dispatch
 
 jobs:
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to PyPI
+name: Publish Library to PyPI
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
       - "*"
 
 jobs:
-  Publish:
+  publish:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish Library to PyPI
+name: Publish to PyPI
 
 on: workflow_dispatch
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,7 +2,6 @@ on:
   push:
     branches:
       - main
-      - feature/release-please
 
 permissions:
   contents: write


### PR DESCRIPTION
# Description
Due to limitations of GitHub Actions, the publishing automation will be done via dispatch.

# Fixes
* Remove on push tags block from publish action.
* Set on workflow dispatch in publish action.
